### PR TITLE
Update to Resonate SDK v0.7.0 (async/await)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ Resonate has built-in service discovery, load balancing, and recovery. And it pr
 In your worker / microservice you can just specify the group that it belongs to:
 
 ```python
-from resonate import Resonate
+from resonate.resonate import Resonate
+import os
 
-resonate = Resonate.remote(
-    group="worker-group"
-    # ...
+r = Resonate(
+    url=os.environ.get("RESONATE_URL", "http://localhost:8001"),
+    group="worker-group",
 )
 ```
 
@@ -62,7 +63,8 @@ Run as many instances of that worker / microservice as you need.
 Then, when you need to call a function on that worker / microservice you use Resonate's RPC API, targeting any worker in that group.
 
 ```python
-result = resonate.options(target="poll://any@worker-group").rpc(promise_id, "function_name", params)
+handle = r.options(target="worker-group").rpc(promise_id, "function_name", params)
+result = await handle.result()
 ```
 
 Resonate handles the rest!

--- a/invoke.py
+++ b/invoke.py
@@ -1,21 +1,28 @@
-from resonate import Resonate
-from uuid import uuid4
+from __future__ import annotations
+
+import asyncio
+import os
 from random import randint
+from uuid import uuid4
+
+from resonate.resonate import Resonate
 
 
-# Initialize an instance of Resonate as a client in "invoke-group"
-resonate = Resonate.remote(
-    group="invoke-group",
-)
-
-def main():
-    # Generate a random compute cost between 1 and 10 seconds
-    compute_cost = randint(1, 10)
-    # Generate a random promise ID
-    promise_id = str(uuid4())
-    # Invoke compute_something() on the worker group
-    _ = resonate.options(target="poll://any@worker-group").begin_rpc(promise_id, "compute_something",  promise_id, compute_cost)
+async def main() -> None:
+    r = Resonate(
+        url=os.environ.get("RESONATE_URL", "http://localhost:8001"),
+        group="invoke-group",
+    )
+    try:
+        # Generate a random compute cost between 1 and 10 seconds
+        compute_cost = randint(1, 10)
+        # Generate a random promise ID
+        promise_id = str(uuid4())
+        # Invoke compute_something() on the worker group (fire-and-forget)
+        r.options(target="worker-group").rpc(promise_id, "compute_something", promise_id, compute_cost)
+    finally:
+        await r.stop()
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,5 @@ description = "Service discovery, load balancing, and recovery example applicati
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "resonate-sdk>=0.6.7",
+    "resonate-sdk>=0.7.0",
 ]

--- a/worker.py
+++ b/worker.py
@@ -1,30 +1,33 @@
-from resonate import Resonate
-from threading import Event
+from __future__ import annotations
+
+import asyncio
+import os
 import time
+from typing import TYPE_CHECKING
 
-# Initialize an instance of Resonate as a worker in "worker-group"
-resonate = Resonate.remote(
-    group="worker-group",
-)
+from resonate.resonate import Resonate
 
-# Register the function with Resonate
-@resonate.register
-def compute_something(_, id, compute_cost):
+if TYPE_CHECKING:
+    from resonate.context import Context
+
+
+async def compute_something(ctx: Context, id: str, compute_cost: int) -> None:
     """A function that simulates a computation that takes some time."""
     print(f"starting computation {id}")
     # Using time.sleep(), instead of ctx.sleep(), blocks the thread, simulating a time-consuming task
     time.sleep(compute_cost)
     print(f"computed something that cost {compute_cost} seconds")
-    return
 
 
-def main():
-    # Explicitly start Resonate instance threads
-    resonate.start()
-    print("worker running...")
-    # Keep the main thread alive to allow async tasks to complete
-    Event().wait() 
+async def main() -> None:
+    r = Resonate(
+        url=os.environ.get("RESONATE_URL", "http://localhost:8001"),
+        group="worker-group",
+    )
+    r.register(compute_something)
+    print("worker running...", flush=True)
+    await asyncio.Event().wait()
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## What changed

Migrates `worker.py` and `invoke.py` from the pre-0.7 generator/threading API to the v0.7.0 async/await API.

- **worker.py**: Replaced `Resonate.remote(group=...)` + `@resonate.register` decorator + `threading.Event` keep-alive with `Resonate(url=..., group="worker-group")` + `r.register(compute_something)` + `await asyncio.Event().wait()`. Function converted from sync to `async def`. Ready line `"worker running..."` preserved with `flush=True`.
- **invoke.py**: Replaced `Resonate.remote(group=...)` + `begin_rpc(...)` (fire-and-forget old API) with `Resonate(url=..., group="invoke-group")` + `r.options(target="worker-group").rpc(...)`. Wrapped in `async def main()` with `await r.stop()` in finally.
- **pyproject.toml**: Bumped `resonate-sdk` floor from `>=0.6.7` to `>=0.7.0`.
- **README.md**: Updated code snippets to reflect the new async API.

## How CI tests it

CI starts a worker with `python worker.py`, waits for `worker running` on stdout, then runs `python invoke.py` as the client (30 s timeout). The worker group name (`worker-group`) and function name (`compute_something`) are preserved exactly as they were.